### PR TITLE
Planemo.toml

### DIFF
--- a/namada-public-testnet-1/Planemo.toml
+++ b/namada-public-testnet-1/Planemo.toml
@@ -1,0 +1,9 @@
+[validator.Planemo]
+consensus_public_key = "00b1dfef9aeff3ccac63665f5071c2533eefe3c9ec1b4dd6dd2673527726efb54b"
+account_public_key = "00d1a496dee4a8425bd12fe76bd9ef507aec6d6a3ecac3bae0a3725b35655ea644"
+protocol_public_key = "0067baec6e0affc90fb1a7b826a54d8b41748aa8400e1981581393ef16708b6e86"
+dkg_public_key = "60000000c232085dc8ee0d84a0e039109c5cc013e4abe01cc1874a8886aaae608aaf1513a5e51a6f2bc72bacac8ec5c39bfc5e16400b2b3b47ccc5b06b00c0b230ebebf3448abbf22c033268e7c242be35f97fc38ff95453ae6fd3f0f68a90937c2c7102"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "92.101.121.233:26656"
+tendermint_node_key = "00817833991402a227b46711d67376d981cdf2d1d032afad3fa3b2437c09d3144f"


### PR DESCRIPTION
My discord: MikeSh#8650
My email: planemostd@gmail.com
Twitter: https://twitter.com/bitcoinduke

Planemo Validator Team is excited to express interest in becoming a part of the Namada Validators cohort. We have a team of experienced devops and validators, who have participated in various projects including KYVE, Ironfish, Massa, Subspace, Agoric, Umee, Minima, Concordium, Casper, Evmos, Mina, Solana, HydraDx, Aptos, Sui and more. We have extensive experience in writing software to track the status of nodes and have a strong background in the space.

We are currently running several nodes on testnets, devnets, and mainnets. We have a wide geographical distribution for our data centers and have experience using VPS and dedicated servers from providers such as Contabo, Vultr, Digital Ocean, Hetzner, Wordlstream, Interserver and more. Our team has been active validators in ecosystems for over three years, participating in more than 30 testnets and currently validating on about 5 mainnets. We have expertise in infrastructure management and community development, as well as experience running relayers and RPC nodes for various projects. 

Our team approach to node management and validation is a priority, we ensure 24hr management and monitoring for every validator or relayer using Grafana, Prometheus, and Telegram alerts. We believe that this attention to detail will ensure the health and stability of the Namada project.

We would be thrilled to have the opportunity to contribute our skills and experience to the Namada project as validators.