### PR TITLE
JeTrix.toml

### DIFF
--- a/namada-public-testnet-1/JeTrix.toml
+++ b/namada-public-testnet-1/JeTrix.toml
@@ -1,0 +1,9 @@
+[validator.JeTrix]
+consensus_public_key = "00a97759874706d91a0fcd96f3867acf44b910cc04aff0f48d9a353794d0294c11"
+account_public_key = "00198b33355f3d203f7b4ddc474e705a4a395474e5c0d6494a0ecf3dc599e79300"
+protocol_public_key = "0031a1036b94f56ff391f0c27df0c6c2faf40b98ad1c7acb78c7e81de56b77ead4"
+dkg_public_key = "600000008321f4e253cbb78bdb2574d20f9f2313b414af30b29f1d94629eddc8c2e8bb2f105349a3953a2ad20c25a317b9f2ab0b002fa0a883fa8c84a8e94208b88b174801fb3d9435ba9295f2acdcdc7c60079073578bb1576e2cb6ee9964ba1db4e989"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "85.10.198.169:26656"
+tendermint_node_key = "005de179f5846590c91fbe69be14fe531e69579a10a89d02fd9d512a044c057a08"


### PR DESCRIPTION
- Discord: JeTrix#8775
- Twitter: @je_trix
- Element: jetrix

- Humanode Mainnet 
hmnyHARKASgh65uEHbEMnjdod74gdh6vgoaWGnizBzPSSabDn

- Obol (on pause, while waiting new stage)
https://prater.beaconcha.in/validator/899d9cf746c0ae45a864907b4f6e0173457682933053434b254518f8f332bda0cb93398493a99c4d24db098ba08d3bab#deposits

- Haqq
https://haqq.explorers.guru/validator/haqqvaloper1udthm3rmyt3fnq6n64r0el7xgr0gwpqlmctp4u

- Celestia
https://celestia.explorers.guru/validator/celestiavaloper1t0289w0eq70h24dvp84g46awpzutdj65ltqa09

- Nolus
https://nolus.explorers.guru/validator/nolusvaloper1jpjdcpg4a33tstecgp5u53fg2ck40dnmha6gpn

- Nibiru
https://nibiru.explorers.guru/validator/nibivaloper1j4ql5cz67fuu3q527xphfq9ajjwvswhh7g62nl

- Empower
https://empower.explorers.guru/validator/empowervaloper1w80g6nxe3005fe2ydpzl27jkvafmzu40umt5al

Other Projects I am/was part of:
- IronFish (waiting new phase start)
- MassBit (running gateway)
- Minima 
- SubSpace
- Dymension (local node)
- GnoLand
- DWS
- Stride
- Bundlr