### PR TITLE
add campbell validator

### DIFF
--- a/namada-public-testnet-1/Campbell.toml
+++ b/namada-public-testnet-1/Campbell.toml
@@ -1,0 +1,9 @@
+[validator.Campbell]
+consensus_public_key = "00565a6cb1fa296037395452da5ead6f0e312848bfc14b36a35060d0ebfec6ca13"
+account_public_key = "002323799058d8ffffa970f523d807df9f70adad76967e72f381537f2339f384ed"
+protocol_public_key = "0025a7b5210fa322035fb3b8b2f18d9aeb4c4b83430733523e0827ffd4e26bab05"
+dkg_public_key = "60000000af809caaedf40daf467be54e77176193bd78780d5901c30687eedfce729dc498866426546cad39bc3cafd2462320d30825d223d5e3951d0df6c0518ff49c6a86956e08d4b517161ffca3d5ac4b7b8fbf5ea00db889b99edb0559e6306b444395"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "159.69.209.122:26656"
+tendermint_node_key = "003dfdd40e8cbe6aa9e0d39fddc72697d70fbc5d25562f2423528e5ad5fa140d70"


### PR DESCRIPTION

Hi,
I’m an experienced node operator, validator and all that may be involved :)
I am a system administrator by education, I am well versed and knowledgeable in Ubuntu and similar systems. I solve any error as quickly as possible without any consequences for the nodes installed on the server.
I know what is important to do to secure my node and server, I respect the rules of privacy, decentralization (I rent servers in the most unusual places, of course focusing on quality as well) and stability. For the last point I always keep a free server, to which I can always quickly and accurately move the node and continue to work on the network.

-Discord Campbell#7946
-Twitter @Davelle229
-Element campbell_

Kyve (Beta — protocol)
https://kyve-beta.netlify.app/#/validators/kyve1w4enttfz9jtx0mghw0eq9rmxspgg5yyewthasn/pools

Kyve (Beta — chain)
https://explorer.beta.kyve.network/kyve-betanet/staking/kyvevaloper1w4enttfz9jtx0mghw0eq9rmxspgg5yyeumha73

Kyve (Korellia — chain)
https://explorer.kyve.network/korellia/staking/kyvevaloper1mhpynfqy9krw7fnpz3g8rsffvxlf3yccrk0wsh

Celestia
https://celestia.explorers.guru/validator/celestiavaloper188ft08px5hryqxe5hawav4q6jugsnj6usny3la

DWS
https://dws.explorers.guru/validator/dewebvaloper1fkzft6dcdzg9qp8t3y3u5ws3fnqmlkaj6kwv7y

Connext (Amarok — liquidity provider)
https://testnet.amarok.connextscan.io/router/0xCc15c6ba86ac91553a15296Cb5611A62c1a6e947

IronFish
https://testnet.ironfish.network/users/61429

SEI
https://sei.explorers.guru/validator/seivaloper10trm8tsqx62c8mrlykgu3w35k9jys0hnja345u

Gitopia
https://gitopia.explorers.guru/validator/gitopiavaloper1n6d5uag7lh2afj7d977nqtnua9frm2qyh9arqh

