### PR TITLE
Add Validatrium as Pre-genesis validator

### DIFF
--- a/namada-public-testnet-1/Validatrium.toml
+++ b/namada-public-testnet-1/Validatrium.toml
@@ -1,0 +1,9 @@
+[validator.Validatrium]
+consensus_public_key = "0048080af9fb919a5465146682737da8cf9f9f59aa8bd0380d8af42863f701056f"
+account_public_key = "004bf0ba932bd7c2839e13906b85606317519fa45dbbd442665630884031bf5bbf"
+protocol_public_key = "00c48e6a1fbdfc130178e8a31dd684cb2e4a4d53b8e7c2a101f89bf5337e6051fc"
+dkg_public_key = "60000000ad58b9d1699446df688f6cfcc72b1ea29297777f7c5957e7619315935bf8671a376f72eca1a103c5c30fa878254dca0bafc5a8b6e6b69ecae42583447ae0927185eac92c2df1e48cad164b9955bb4c07cb54889d2956046bf79d9d9af63d6810"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "65.108.101.19:20156"
+tendermint_node_key = "00734a9a0caa61ae5170d715cf501fae28e97161247592c1d9f8b9d61e26db9eec"


### PR DESCRIPTION
Validatrium is a great team of 16, where each member is a professional in his field. We have: Devops, Fullstack Devs, experienced community (5) and tech (2) managers. Over past two years we have set up 100+ nodes in 65+ networks, including ETH 2.0, Hydra, Kava, Polkdadex, Oasis, Kusama, Velas, BitSong, Centrifuge, Axelar, Evmos, Forta, Clover, Ki Chain, Umbrella, Sifchain, Lum, Near, Kava, etc., with fair rates and continued support to the community. Validatrium takes part to benefit each project we are working with, we tend to create different tutorials to support community with a step-by-step solutions on running nodes, creating wallets, using faucets, staking, setting up node health check notifications, etc. Depending on the project, our team is always trying to find the best solution to engage community and create something special to ease process of joining the project and developing it. Team is always ready to answer questions via discord, telegram, twitter, etc. Validatrium has it’s own community channels, where we promote projects, share tutorials, and let our community know about any critical updates and contests. Additional information may be accessed at our website: https://validatrium.com

Discord: [validatrium] Yuri Tech#0264
Element: yu_validatrium
Twitter: https://twitter.com/validatrium
Email: validatrium@gmail.com
Community manager discord: Maryna | Validatrium#0577
Community manager email: m.ruska@validatrium.com