### PR TITLE
add Conqueror.toml

### DIFF
--- a/namada-public-testnet-1/Conqueror.toml
+++ b/namada-public-testnet-1/Conqueror.toml
@@ -1,0 +1,9 @@
+[validator.Conqueror]
+consensus_public_key = "00a344d8b133457399e38ad286ee31e08dc30b7cb62a2884150db971c2da71298d"
+account_public_key = "008f7f55080be063e07e5a60058ac27c1f2738e53cd2ab9f9d31bb84fba2e817a3"
+protocol_public_key = "001c1d20e2c8dfb888292748c5212cf83e54c3ae865287356e891643ac3d2b11ab"
+dkg_public_key = "60000000f140cd8538122e84b92f6cbc2d57ed12c24dbb2bcf99b6bd1a11cd3e5948b59428adc2ea3d05c2971c9a9996e7208b0ce961b6d15087a6eadc6afd69fe2ef4fa82c6b568f247e5615a375ba35fb87390cc503fe650a62b6fe37d8df3eb08e60a"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "65.109.106.214:26656"
+tendermint_node_key = "00b73fb9395ac1498a41cce299d60ac10c6abef8f616bfd55040e7301f2f16392c"


### PR DESCRIPTION
Twitter: @Conquerorr_1
Discord: Conqueror#1312
Element: conqueror_
Telegram: DasRasyo
Github: https://github.com/DasRasyo

Testnets I'm currently actively participating in:
Celestia, Paloma, Uptick, Nibiru, Lava, Gitopia, Humans.ai, Power, Mun, Obol. Mainnet Validators: Humanode, C4E
Nodes: Phantom Testnet, Avalanche Fuji, Avalanche Mainnet

Links:
https://celestia.explorers.guru/validator/celestiavaloper17vmk8m246t648hpmde2q7kp4ft9uwrayy09dmw https://paloma.explorers.guru/validator/palomavaloper174l5um5rahquqxlvchyhfeveuue7j8fapw2hkd https://uptick.explorers.guru/validator/uptickvaloper198rdpmvkvvrvl7wwlvk7j3fylk7j0f9jewyjt0 https://nibiru.explorers.guru/validator/nibivaloper19gseerqk23yyaufkczm4kjsqeclqjhrx42t6zq https://lava.explorers.guru/validator/lava@valoper1x9a0dfvx37cxtmuk6kx83jua8cedtslfkzvvul https://gitopia.explorers.guru/account/gitopia1t0h8a04jw5xt6zujak2renne5hddy3c49cvvq8 https://explorer.secardnode.com/chain4energy/staking/c4evaloper1djg8nylg2jdpxad73xwqtfdcqe5cxkmf552ec4 https://explorer.humans.zone/humans-testnet/staking/humanvaloper1dcftqperhzl87axk6wm2d6umv24l6udfrpxrjh https://prater.beaconcha.in/validator/0xb1fbb81e68cd47822c19e649b29ca514bdf4e8c3e162fb7de8628808770f721afb60800de19379eabda151c74ce4aeba#deposits

I involved in the testnet processes of Aleo, Sui, Meson, Archway, Quicksilver, DWS, Omniflix, Cosmic Horizon and much more.

I will also be happy to take part in the Namada.