### PR TITLE
🔥STAVR🔥

### DIFF
--- a/namada-public-testnet-8/STAVR.toml
+++ b/namada-public-testnet-8/STAVR.toml
@@ -1,0 +1,9 @@
+[validator.STAVR]
+consensus_public_key = "00d8197e65312e5fefcdfbb07f8816e92db78929b90e34d16942a71b14da12ea90"
+account_public_key = "00bbe228c2e80bc8f22741b8c8dc71651bca4815d11ee83b8da606082f07082409"
+protocol_public_key = "006edc1d58dc9a58b179a457e2c11f8098847f1146efa3bab628e6fe8cd5d29c94"
+dkg_public_key = "600000001ec0e5300d416c209b40bb3ed9960ce6c536490b140ee5290f2ff38244c759b3d82dbe3fc8a1d5904bd5ca423a4a3c18490861f8f3b1082a0e4cb9ba899cac7fb5affe1c70309a6e4e06a1d1213a0fbfb15cf24e36c87a34b13240ce1c498600"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "93.190.141.68:26656"
+tendermint_node_key = "0008aaf8d42335cad401d70c9a33d31dec36bd0e0c54d2b9783e4a5e68e005fb7b"


### PR DESCRIPTION
![burn logo (1)](https://github.com/gitopia/mainnet/assets/44331529/306c81f7-d776-47e8-bded-d033c9ac6e31)

<h1 align="center"> STAVR foundation</h1>

<h4 align="center"> :earth_africa: A community of tech-savvy crypto enthusiasts from around the world. (decentralization) welcomes you :earth_africa:</h1>

🟢In the crypto industry since 2017. Experience in validation and programming - more than 4 years.
We work with all popular and new/unique blockchains. We help projects develop in the early stages, as well as support the finished products of projects. \
:wrench: `Safety and reliability are a priority`. We cooperate with the best data centers in Europe, America and Asia. \
 :gear:25/7 management and monitoring! (Grafana + Prometeus + Discord/Telegram alerts + Tenderduty)
 
 <div align="center">
  <div style="display: flex; align-items: flex-start;">
 <img align="top" src="https://komarev.com/ghpvc/?username=obajay&color=brightgreen" height='35'/>
<br />
<br />
  </div>
</div>

#
 <div align="center">
 
[<img align="center" src="https://user-images.githubusercontent.com/44331529/190991117-92cba33a-637c-4870-b652-34d255f87995.png" alt='discord' height='70'>](https://discordapp.com/users/765663833049661530) [<img align="center" src='https://user-images.githubusercontent.com/44331529/190991712-4d6212ff-3a9d-422d-8b33-739ac76c00d8.png' alt='telegram' height='68'>](https://t.me/STAVRRR)
<br />
<br />
  </div>
</div>

#
<div align="center">
 
### Cosmo-EXPLORER, IBC Relayers, TenderDuty
[<img src='https://user-images.githubusercontent.com/44331529/193394591-5d0c2dd0-1993-45fe-82fb-7a56e6a75c78.png' alt='discord' height='120'>](http://explorer.stavr.tech/)[<img src='https://user-images.githubusercontent.com/44331529/200136962-d77c52cb-78f2-4bb1-b2a3-7126ed72eac5.png' alt='discord' height='120'>](https://github.com/obajay/IBC_Relayers)[<img src='https://user-images.githubusercontent.com/44331529/200166434-0c43daa1-d83d-4024-bcd8-03376098f3b5.png' alt='discord' height='115!'>](https://tenderdutyv2.stavr.tech)
    <br />
<br />
  </div>
</div>

#
[<img src='https://user-images.githubusercontent.com/83868103/183111052-2bc3a8cf-f5b7-4915-8a09-212f09859e34.gif' alt='mainnets'  width='99.5%'>](https://github.com/obajay)
[<img src='https://user-images.githubusercontent.com/44331529/196050531-bb8822ed-32af-4610-8cdc-b0bee55d5cde.png' alt='discord' height='112'>](https://explorer.stavr.tech/sifchain/staking/sifvaloper1k5ypsesvvfga6pxjdxggaph97ywwf4l4mw0mqp)[<img src='https://user-images.githubusercontent.com/44331529/196249857-60bf7ea3-6304-4d00-94f5-1c991b9d07fe.png' alt='discord' height='112'>](https://explorer.stavr.tech/gravitybridge/staking/gravityvaloper1qz50nzevfjqaftt67twfr2tzajc27uv7n5ttfv)[<img src='https://user-images.githubusercontent.com/44331529/196249834-9814ebf4-4097-4471-a5dc-0591e67838c4.png' alt='discord' height='112'>](https://explorer.stavr.tech/agoric/staking/agoricvaloper16w8w9l89av0vey6gdreatkuh43n69u7je2t7l2)[<img src='https://user-images.githubusercontent.com/44331529/196249847-9f17767f-c1f0-4f8f-889c-9de4b44d9e15.png' alt='discord' height='112'>](https://www.mintscan.io/evmos/validators/evmosvaloper1v3q2kuups8gzjk2930haevwn08gl9vfld69m9g)[<img src='https://user-images.githubusercontent.com/44331529/196249864-d341b60c-852f-412a-b0ed-389659960612.png' alt='discord' height='112'>](https://explorer.stavr.tech/lambda/staking/lambvaloper1pkldxj2cnrhajx0fms2gxlzhh6k2gcg5k88a83)[<img src='https://user-images.githubusercontent.com/44331529/221395072-ae9a14ca-1cdb-4a8e-a41f-ecbd5915437f.png' alt='discord' height='112'>](https://explorer.stavr.tech/meme/staking/memevaloper1hjd7mxw0lvvu6vqkcpglte2f4u8gy4r5lkxqcs)[<img src='https://user-images.githubusercontent.com/44331529/196249814-61332d86-d313-49f2-b051-59eb505a6b3a.png' alt='discord' height='112'>](https://mixnet.explorers.guru/mixnode/4RfTcrahCMW4omkkfsmPsAdPzisX8HpYEDaL4DtpdTCe)[<img src='https://user-images.githubusercontent.com/44331529/196249819-a3dd80dd-99dc-43b8-bbc9-5790e730a3db.png' alt='discord' height='112'>](https://explorer.stavr.tech/provenance/staking/pbvaloper1vclg6sh22dcnr3klslqfux6jpsr4dl5nkwx4zm)[<img src='https://user-images.githubusercontent.com/44331529/196249831-71076bbf-793c-49e4-ac13-341279fa9092.png' alt='discord' height='112'>](https://explorer.stavr.tech/umee/staking/umeevaloper1dkjcas3j43u3v6l94jhhhnjxhlnwxt3m02p4c3)[<img src='https://user-images.githubusercontent.com/44331529/196249850-d96285b3-ca95-4890-8fef-1925672c35fc.png' alt='discord' height='112'>](https://explorer.forta.network/network)[<img src='https://user-images.githubusercontent.com/44331529/196249860-94571e87-cb9e-417b-9d26-0b1767d94b1e.png' alt='discord' height='112'>](https://explorer.stavr.tech/idep/staking/idepvaloper16jd3xjhl0kjgmuqguut0adxpfdhrmz26mgvd8n)[<img src='https://user-images.githubusercontent.com/44331529/196249868-3d12603b-8265-40bc-acd4-d5dffd97ab33.png' alt='discord' height='112'>](https://explorer.stavr.tech/mises/staking/misesvaloper1dj7dyrz30ap65etcj6v55w4jtz07utaukvqc8z)[<img src='https://user-images.githubusercontent.com/44331529/196249839-7cb995d8-d4fb-433a-8884-c225296710b7.png' alt='discord' height='112'>](https://explorer.stavr.tech/bitsong/staking/bitsongvaloper1c5p4sqgz5jslpywsk5c0nasqqjfucv9lvjlnry)[<img src='https://user-images.githubusercontent.com/44331529/196249846-a2ed2184-dea8-4b31-bc4d-52b110d341c8.png' alt='discord' height='112'>](https://explorer.stavr.tech/dig/staking/digvaloper1lzs9a922fygv2dlm97jgfqm9ueqq3rj938kqdq)[<img src='https://user-images.githubusercontent.com/44331529/196249836-590b2f84-d3cf-4a30-bd16-e530f06a71bc.png' alt='discord' height='112'>](https://explorer.stavr.tech/beezee/staking/bzevaloper16zk776px8ef00hmd59vgnueegyrkk3lja0nhy4)[<img src='https://user-images.githubusercontent.com/44331529/196249862-1a15b4f2-24aa-4b7b-9aee-1bb41b5dfcd3.png' alt='discord' height='112'>](https://explorer.stavr.tech/konstellation/staking/darcvaloper1krlfcngvstzxdy84v0vsfydefmju9wuhdnq03j)[<img src='https://user-images.githubusercontent.com/44331529/196249821-9a730b89-964e-480d-9f92-2f0c69b40f9b.png' alt='discord' height='112'>](https://explorer.stavr.tech/rizon/staking/rizonvaloper1w7ayxavsjahthtkfdzs8gp75htn30gxru4pmzk)[<img src='https://user-images.githubusercontent.com/44331529/196249855-6118018d-0615-46d9-bc35-28141531ea41.png' alt='discord' height='112'>](https://explorer.stavr.tech/genesisl1/staking/genesisvaloper1p4n3fy8wqmn4ja0fp4lenaemyzlxrp6ysrhxfj)[<img src='https://user-images.githubusercontent.com/44331529/196249844-e271d2da-cb1d-40a9-b227-f42abd2981c0.png' alt='discord' height='112'>](https://explorer.stavr.tech/canto/staking/cantovaloper1tav4ldqxyjhcymdhswxrjrmy69un2yh4vpfhtt)[<img src='https://user-images.githubusercontent.com/44331529/196249827-c76ec48c-faec-40e3-870c-144f74552ce1.png' alt='discord' height='112'>](https://explorer.stavr.tech/stride/staking/stridevaloper1n94ndmxqf7vke553lr3ewwt4edtc4g6mdyx9qn)[<img src='https://user-images.githubusercontent.com/44331529/196249820-5cb2e6b0-b4f1-44d6-b747-d5eee2f7471d.png' alt='discord' height='112'>](https://explorer.stavr.tech/rebus/staking/rebusvaloper18yh3xfp43tpla6hd6wzdxu5lhwfcf3f54gnhey)[<img src='https://user-images.githubusercontent.com/44331529/196249838-527aa97d-4bd1-4012-bdbb-5e79dcf7a6d6.png' alt='discord' height='112'>](https://explorer.stavr.tech/bitcanna/staking/bcnavaloper19tyve4e8nf0twd8z02a2eatrls7tuecy0ef098)[<img src='https://user-images.githubusercontent.com/44331529/196249829-e451f661-fd3a-4490-a650-b1cd95957895.png' alt='discord' height='112'>](https://explorer.stavr.tech/teritori-main/staking/torivaloper1sqk72uwf6tg867ssuu7whxfu9pfcyrpeqwa92c)[<img src='https://user-images.githubusercontent.com/44331529/196860226-fdf2b19f-6fdd-4e81-8e9f-7121858634bf.png' alt='discord' height='112'>](https://www.mintscan.io/tgrade/validators/tgrade1pmhg449rk990w2acau2q2cpmh2m5333rjje9td)[<img src='https://user-images.githubusercontent.com/44331529/198509225-8371387f-5aaa-4671-bc50-29dbe2cd815d.png' alt='discord' height='112'>](https://explorer.stavr.tech/jackal/staking/jklvaloper1us3q2ytkn9zyn99gvf66u6nsn3wnq0n3kxpyvm)[<img src='https://user-images.githubusercontent.com/44331529/206961732-184767bf-bd8a-4181-8329-6f5fba94f0c6.png' alt='discord' height='112'>](https://explorer.stavr.tech/pylons/staking/pylovaloper1ug6vwrspderzxg2wjgpsnenlkvj8jj5v72s9um)[<img src='https://user-images.githubusercontent.com/44331529/208226444-fff7ecda-75e5-4346-8fbd-09ba2ca5ff2b.png' alt='discord' height='112'>](https://explorer.stavr.tech/quicksilver-mainnet/staking/quickvaloper198arckkz24ag0c32pnhmxpfe2hyu7gkvp9tnmn)[<img src='https://user-images.githubusercontent.com/44331529/216750935-5858d3e6-dacc-4412-b444-80b340d9b858.png' alt='discord' height='112'>](https://explorer.stavr.tech/mars/staking/marsvaloper1pc3ahwcurfedenmmndtk6w4nv7yj08ywfyenqf)[<img src='https://user-images.githubusercontent.com/44331529/217156238-6bccc456-6ef0-40ca-9783-cd865169e722.png' alt='discord' height='112'>](https://explorer.stavr.tech/c4e/staking/c4evaloper1gc6vs2j3g2jpy2mzrwpmmwju9eafhn0gwx8lv8)[<img src='https://user-images.githubusercontent.com/44331529/222480082-4f86a011-63e8-4448-88c8-405c1d160748.png' alt='discord' height='112'>](https://explorer.stavr.tech/juno/staking/junovaloper177svs8gyz28pupaj6amgls6rahcmwmwq06fukv)[<img src='https://user-images.githubusercontent.com/44331529/222918795-92db9d2b-a46a-43e3-a0eb-aabe9e6d838c.png' alt='discord' height='112'>](https://explorer.stavr.tech/arkh-mainnet/staking/arkhvaloper1x5zx3tlcmy323jg6jnzt6qfxy5wgq587sx90fw)[<img src='https://user-images.githubusercontent.com/44331529/224076954-8a5b832d-54f9-466d-9864-af6217197e8c.png' alt='discord' height='112'>](https://telemetry.w3f.community/#list/0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe)[<img src='https://user-images.githubusercontent.com/44331529/224935929-b33e72e4-6d1d-48b0-bf9a-1d1f5a1a430f.png' alt='discord' height='112'>](https://explorer.stavr.tech/kyve/staking/kyvevaloper16qwtkeadppy3u9z6pu9tuy8zq02u3vecun3s0d)[<img src='https://user-images.githubusercontent.com/44331529/226328973-85dd46d4-9a09-4460-a046-737a3b2161fe.png' alt='discord' height='112'>](https://explorer.stavr.tech/aura-mainnet/staking/auravaloper1ucp33srru7g45ku6w207kc4hy6xd6psvmxw3xf)[<img src='https://user-images.githubusercontent.com/44331529/227769309-3560be31-ae73-4c8e-9b54-bb134a435701.png' alt='discord' height='112'>](https://explorer.stavr.tech/uptick-mainnet/staking/uptickvaloper1n9urj4d6mngtuhpfysdxu7nq72e8830wkx5mug)[<img src='https://user-images.githubusercontent.com/44331529/228142632-fbf909c0-d7b2-4bbf-b87b-dcf774d99e32.png' alt='discord' height='112'>](http://explorer.stavr.tech/nois-mainnet/staking/noisvaloper1enwhnv85g4n99a2kzg8gey22xu6u43l4cxj824)[<img src='https://user-images.githubusercontent.com/44331529/230655657-5f887a53-bb38-4fea-baf9-8ec79f6565b8.png' alt='discord' height='112'>](https://explorer.stavr.tech/realio-mainnet/staking/realiovaloper1n99gv9edgtvktcpxld6x9cp6zvq7e28mzjwwg4)[<img src='https://user-images.githubusercontent.com/44331529/231431091-717c33ea-e7f4-4494-a20d-e1b219b1f070.png' alt='discord' height='112'>](https://explorer.stavr.tech/terp-mainnet/staking/terpvaloper1eff25w2su9zxhe9lzea65l9xyptv8saxj6r2c8)




#

[<img src='https://user-images.githubusercontent.com/83868103/183112064-24d8012d-8808-49dd-add7-d1a631e18170.gif' alt='activetestnet'  width='99.5%'>](https://github.com/obajay)
[<img src='https://user-images.githubusercontent.com/44331529/197253088-c73a6af7-49dc-4d2c-9b73-16933bfe0a1e.png' alt='discord' height='94'>](https://www.aleo123.io/address/aleo17lecd9zfgc585640vkd2h898a3w8qem7zdevt57y0sm97d4wwqxqlqms6x)[<img src='https://user-images.githubusercontent.com/44331529/197253108-1ca23518-b27f-477e-a476-c43bb1008062.png' alt='discord' height='94'>](https://explorer.stavr.tech/cardchain/staking/ccvaloper1s9fljs8pfz60qqg6wj6hxhu82tjfqu6yaep9s7)[<img src='https://user-images.githubusercontent.com/44331529/197253110-b7cdb584-6798-4508-b878-dbed842028a4.png' alt='discord' height='94'>](https://explorer.stavr.tech/defund-testnet/staking/defundvaloper14wa33x0sssc6et3e2js08fhxe75evcpdalpe5z)[<img src='https://user-images.githubusercontent.com/44331529/197253118-3c4b179b-f1f7-429c-a240-461782d59bfe.png' alt='discord' height='94'>](https://explorer.stavr.tech/haqq/staking/haqqvaloper1yj2hjxsu7gxcdje86hgnm9gn7z09ua9vhjx6pn)[<img src='https://user-images.githubusercontent.com/44331529/197253124-7a13b693-9771-497b-9575-58337f486026.png' alt='discord' height='94'>](http://explorer.stavr.tech/hypersign/staking/hidvaloper1mgvq7xersraskutl0d8x0zyk3m24hc6u8zcm0h)[<img src='https://user-images.githubusercontent.com/44331529/197253126-d445e77f-0d2c-4039-890a-9b3fa2a233ba.png' alt='discord' height='94'>](https://testnet.ironfish.network/leaderboard)[<img src='https://user-images.githubusercontent.com/44331529/197253129-dd72abcb-ef0b-450f-995b-9ae9b87a5293.png' alt='discord' height='94'>](https://explorer.stavr.tech/mande-chain/staking/mandevaloper104v2uksujl8scw2zlzvxnutgw08vvla498fh09)[<img src='https://user-images.githubusercontent.com/44331529/197253134-4f764a04-7c0a-46b1-a106-e1f4ddd5768f.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197253139-7b18238d-6d67-403a-9a23-5f54de85b102.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197253148-7ee07a5c-9810-4de0-8a6c-0870b01a3d6f.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197253160-89fefadc-dd5c-4962-90db-07ccc23f7572.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197253164-40791372-4f12-41c3-a107-5b62942532f8.png' alt='discord' height='94'>](https://explorer.stavr.tech/realio/staking/realiovaloper1n99gv9edgtvktcpxld6x9cp6zvq7e28mzjwwg4)[<img src='https://user-images.githubusercontent.com/44331529/197253179-643c6ded-1485-4734-9e99-15ab4a6f953c.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197253171-5144e5f8-a7cd-4fca-b211-57acb1c08155.png' alt='discord' height='94'>](https://explorer.stavr.tech/source/staking/sourcevaloper13l78szv3mxcru9mhh2ndv58xla2arfzhv045cx)[<img src='https://user-images.githubusercontent.com/44331529/197253173-d36891c8-49e5-47da-afb4-84ede8945bc7.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197253182-209a4f02-33af-4ab7-aba4-eb29878dddbd.png' alt='discord' height='94'>](https://explorer.stavr.tech/teritori/staking/torivaloper1qttw95d6xk0nhk3mc63ueg29xap4msu3xndcnn)[<img src='https://user-images.githubusercontent.com/44331529/197253187-8652af68-6140-4a20-8d9f-8e21b089badb.png' alt='discord' height='94'>](https://explorer.stavr.tech/terp-network/staking/terpvaloper1eff25w2su9zxhe9lzea65l9xyptv8saxj6r2c8)[<img src='https://user-images.githubusercontent.com/44331529/197253190-2a475ef9-cd5b-43c2-8add-0b59d6fe4184.png' alt='discord' height='94'>](https://explorer.tfsc.io/#/pc/BkHash?query=1LvpoUwuGmY3E1DavzF7Q6iAicNF7oveuP)[<img src='https://user-images.githubusercontent.com/44331529/197253192-54a30c86-751f-4deb-ad13-f20f7dc6706a.png' alt='discord' height='94'>](https://explorer.stavr.tech/uptick/staking/uptickvaloper1n9urj4d6mngtuhpfysdxu7nq72e8830wkx5mug)[<img src='https://user-images.githubusercontent.com/44331529/197317006-5436cf63-7d4e-4947-96ff-896bd5969695.png' alt='discord' height='94'>](https://explorer.stavr.tech/umee-canon/staking/umeevaloper13k8p5q678ld8k7y2mv35kurl8ucskjzks0qlfa)[<img src='https://user-images.githubusercontent.com/44331529/197370779-1efced31-1ae7-41ba-a02f-3fab17119e49.png' alt='discord' height='94'>](https://explorer.stavr.tech/andromeda/staking/andrvaloper1xsm4dvmh5txrcteyv3yq5z8pm58mu35365tpzq)[<img src='https://user-images.githubusercontent.com/44331529/197676263-37476286-e7f2-410f-b99a-b3f64a7298a4.png' alt='discord' height='94'>](https://explorer.stavr.tech/bitcanna-dev/staking/bcnavaloper1hn0hc4c6786xtka8pzy5qyrlv276d26arvkv59)[<img src='https://user-images.githubusercontent.com/44331529/199457949-c8daf894-b4ec-4baf-9074-e897a0a4aa6c.png' alt='discord' height='94'>](https://explorer.stavr.tech/nibiru/staking/nibivaloper1vgh5ry6zwjp007f90wfwgung6l4z6330tmqsw4)[<img src='https://user-images.githubusercontent.com/44331529/200649846-32a218a2-2893-42aa-8c5d-861945fefb41.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/200923437-91689140-6df4-4a33-8245-a237d6875908.png' alt='discord' height='94'>](https://explorer.stavr.tech/gitopia-testnet/staking/gitopiavaloper1ztlnz9v3qqmq828dp6rj3ndu7gvju63m3az0ym)[<img src='https://user-images.githubusercontent.com/44331529/203029915-ba437f2b-f433-4bbc-97e2-a391759d837d.png' alt='discord' height='94'>](https://stake-perseverance.chainflip.io/auctions)[<img src='https://user-images.githubusercontent.com/44331529/204242150-9f7632c1-7cc6-441d-bfb5-9ad5a5fa6503.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/205274606-78b9528e-5154-4047-8518-e7fd7fc8b575.png' alt='discord' height='94'>](https://explorer.stavr.tech/jackal-testnet/staking/jklvaloper1apaj3552wv4umcwrxm9ggx6hr7ttck5kha7sat)[<img src='https://user-images.githubusercontent.com/44331529/210713570-863ddf73-7c6a-4550-becd-b72af873e885.png' alt='discord' height='94'>](https://explorer.stavr.tech/lava-testnet/staking/lava@valoper1pwrwgqe8lke6c6y9md2cnwznlutzlv867kt4mc)[<img src='https://user-images.githubusercontent.com/44331529/218157564-8700b6c0-6d51-45cd-8b8d-b00f0a6bd97c.png' alt='discord' height='94'>](https://explorer.stavr.tech/althea-testnet/staking/altheavaloper1dmhvufcxxh0r3kf36ktwv7ff5ew20paq952h2s)[<img src='https://user-images.githubusercontent.com/44331529/218537238-46fcc78e-5344-4d1b-9b86-a5e2aa289f86.png' alt='discord' height='94'>](https://explorer.stavr.tech/andromedad-testnet/staking/andrvaloper1xsm4dvmh5txrcteyv3yq5z8pm58mu35365tpzq)[<img src='https://user-images.githubusercontent.com/44331529/219106455-c7dc5fc9-f730-4ef7-9d9a-f38ce1c41c30.png' alt='discord' height='94'>](https://explorer.stavr.tech/dymension-testnet/staking/dymvaloper17jaxv5u8z0l34z2cku9jqjd4rln8096w8umpn9)[<img src='https://user-images.githubusercontent.com/44331529/219939237-adc11014-baac-41c9-a21e-ec224bdd0d00.png' alt='discord' height='94'>](https://prater.beaconcha.in/validator/8a4e1b747d47925746be3ba3b755cde35bc1866f152eed2fac740a41710c9855caac8ee5933fab3ab61c89ad8fcccada#deposits)[<img src='https://user-images.githubusercontent.com/44331529/206636146-5a2b0b9e-65fc-407f-92f5-3319996d0bb4.png' alt='discord' height='94'>](https://explorer.stavr.tech/humans-testnet/staking/humanvaloper1xq9msyjv4pdhgv0wu33wyd99wf3ffwsc35ptax)[<img src='https://user-images.githubusercontent.com/44331529/208226368-cb65fae9-c8fe-4e40-9f49-3ac212b4bc17.png' alt='discord' height='94'>](https://explorer.stavr.tech/quicksilver/staking/quickvaloper1hm6t24g6dxkp7dk6pn2hn379pdupvd5r3s6z3q)[<img src='https://user-images.githubusercontent.com/44331529/233251131-617d0dbc-e6ff-441a-93a7-437aa06a80d1.png' alt='discord' height='94'>](https://namada.world/)[<img src='https://user-images.githubusercontent.com/44331529/210718133-d302b819-24a8-412a-9b5f-d6d4db4a0e16.png' alt='discord' height='94'>](https://explorer.stavr.tech/okp4-testnet/staking/okp4valoper1sc4dkm38ejwftlxfwj9tx6dq8tdd3e9ygascc8)[<img src='https://user-images.githubusercontent.com/44331529/222905615-a84e0aa1-83b8-41bd-a0c6-f775157ef34c.png' alt='discord' height='94'>](https://explorer.stavr.tech/juno-testnet/staking/junovaloper1qns2cgfa0y0s4x37vkd8dtkutj5kveekxpf6jd)[<img src='https://user-images.githubusercontent.com/44331529/222914806-6b558c2f-e751-4da8-a884-58fc467b5a3f.png' alt='discord' height='94'>](https://explorer.stavr.tech/sao-testnet/staking/saovaloper1am03n3gnc4ylhyj7uyn4dv73ysyfk70yplu3lh)[<img src='https://user-images.githubusercontent.com/44331529/223435098-cbab7e3d-c3f9-47a2-a64f-0069e26b6d5c.png' alt='discord' height='94'>](https://explorer.stavr.tech/ojo-devnet/staking/ojovaloper1cw9f2xn072ll9g5q76d5cg7us9s4gp8903mcel)[<img src='https://user-images.githubusercontent.com/44331529/225716717-eb2c6e2e-19c9-4410-8030-9c27d0b8dc4b.png' alt='discord' height='94'>](https://explorer.stavr.tech/sge-testnet/staking/sgevaloper105xysdmvy6xyz3ytyk62fgkwyczx2n4vzkyp6g)[<img src='https://user-images.githubusercontent.com/44331529/228544729-8d10a50a-d9b8-4648-b1ef-5efdff299e26.png' alt='discord' height='94'>](https://explorer.stavr.tech/nois/staking/noisvaloper1mgdef8haxlvxmml25m2uwlmljqznlsjmw3y893)[<img src='https://user-images.githubusercontent.com/44331529/231103045-ab8e7da8-395e-4179-ab7c-b149d09cce47.png' alt='discord' height='94'>](https://explorer.stavr.tech/elys-testnet/staking/elysvaloper1ztfn9tjxudwyeaq25evydz2mv6803cy59jlj2z)[<img src='https://user-images.githubusercontent.com/44331529/232399065-df16370e-b242-4070-b4f1-89914df557a5.png' alt='discord' height='94'>](https://explorer.stavr.tech/cascadia-testnet/staking/cascadiavaloper1cvw68h268ndl24qpc4rammjawj3t8cm8rmf92z)[<img src='https://user-images.githubusercontent.com/44331529/233453445-0730a292-30ee-45e7-9fe9-77853b1f06be.png' alt='discord' height='94'>](https://explorer.dev2.eywa.fi/validators/?search=stavr&p=1)[<img src='https://user-images.githubusercontent.com/44331529/234510514-90400cd0-ffae-43de-88b7-c6d026dae9da.png' alt='discord' height='94'>](https://explorer.kjnodes.com/composable-testnet/staking/banksyvaloper180wngzau7jzdw9xdqp0a4mm7740y5rfzhkwr5u)[<img src='https://user-images.githubusercontent.com/44331529/235335329-b7cb5867-a6d9-4f2f-8425-e02917eed697.png' height='94'>](https://explorer.stavr.tech/sei/staking/seivaloper146svnkgyvpqstswdkmvlzxmnvwffluqgh4yd3f)[<img src='https://user-images.githubusercontent.com/44331529/235717704-b2ba25e1-ee6e-4855-96a1-31e8ddaaf186.png' height='94'>](https://explorer.stavr.tech/bonusblock-testnet/staking/bonusvaloper156jkdw7s0gvrl8w8w2gxgh4dujm7mhchxg9ra0)




#

<div align="center">
<details>
  <summary>🔴ARCHIVE ARCHIVE ARCHIVE 🔴</summary>

  [<img src='https://user-images.githubusercontent.com/83868103/183119780-7b6a498b-11d9-4d15-b14c-836db65ca6f2.gif' alt='inactive'  width='99.5%'>](https://github.com/obajay)
[<img src='https://user-images.githubusercontent.com/44331529/197408680-3abf1b6f-65d0-4e3f-a4f4-56c94a8f2c35.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408685-da3b589c-b88f-4346-b601-f56ee49d2ec9.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408686-ea54159a-fd9a-49b9-8b26-fbc4dcad0065.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408687-90ac4539-e26a-4fc2-812d-dc99726d1960.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408689-0b9eb430-1b9b-4916-bcdf-662fe59ea2f0.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408691-a593ed7f-93e5-4ceb-b6a9-207fb2bfd698.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408693-be358086-d876-4426-bf92-b22123578883.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408696-240060a0-bb8b-4ffa-a4d6-57043999ae89.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408697-1771f4aa-fa25-4b61-aa6a-13cae3a81eb5.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408698-91af94e1-4f8b-4ced-a591-7f61ba56a8c5.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408701-64f37099-e422-4ba0-bae6-10596e17c0b1.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408702-6836c0cf-f967-4dab-b28e-14275c47124b.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408704-a4f5c731-01f1-45e2-9b58-49ce14863db4.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408705-f5265615-e7f7-4bbb-bca4-ff3a812987ce.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408707-17524499-2e4e-42a5-a4bc-9e694c88ad6e.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408708-61ef4bc7-5cdd-447c-beee-ee04e475bbb0.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408709-79abe917-63ee-4889-a880-ae2b516b9a49.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408710-ecf257a7-b224-4af3-bfab-bec06438272e.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408713-016e03fe-3b63-49ef-b5a6-0ae5a7678515.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408714-35cd41cb-8bb8-4382-b1cd-1ab3c0cbf718.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408715-2f3cbe0f-76e7-4101-a865-a651d58b926b.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408716-20b76777-e994-42db-aa9e-680f49cb5bf5.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408717-4ff2d476-c864-47cc-a053-4f9773e53d08.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408719-14d700eb-e838-41f9-a2cc-a4c3461e3f14.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408720-5b7f369f-1127-4133-b40f-61c2c792ed4f.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408721-372f61a9-aed3-475e-adfe-af6bd106df67.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408723-5818ac1d-adb6-465c-9134-dbd71c919dfd.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408724-bd5cf252-bc6a-4c0d-a619-d0bbfb2239f7.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408725-13747a9a-45eb-460b-b5f9-bc07ffe0752a.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408726-30ef95bb-e718-496f-a7de-0b2d3513013d.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408728-35f68dbc-ca39-4784-9c74-30394423f015.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408729-406ab2ef-8462-4e00-8be8-8ec97266cbff.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408730-17cc8574-c6a7-4f3e-9340-08c3e2425984.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408731-8a06e355-2836-405e-a535-16f82c62ad26.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408732-d3f4875e-8403-431d-b852-27248502a9c9.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408734-7f3cbca9-a12a-4e61-8569-63c1c6a7caeb.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408735-1c6ac723-cd5e-4329-832a-a965ffa7c599.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408736-4d77a14b-fd0f-42a8-b914-040105776f8d.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408737-8fec0dfe-30ee-4127-921d-bf819aa44a33.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/197408739-8828df62-9f3f-4c9f-b52a-5fa74207bcda.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/199476873-40ce29bb-cdfd-40e4-80a5-f6be064e9aed.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/199677360-98eac4de-235e-4979-a864-d6460c1c7f07.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/200108159-07709553-8ea4-4a10-98df-027c84f192e9.png' alt='discord' height='94'>](https://coho.explorers.guru/validator/cohovaloper1mrr2tj92fqv0wgzlhwyet8e23l84h0u0hrr4tj)[<img src='https://user-images.githubusercontent.com/44331529/202128098-bfe9e73d-109f-404f-8b30-da6a25f27553.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/205269182-ea8642fa-6be8-449a-bb3b-ffa01900f5b7.png' alt='discord' height='94'>](http://explorer.stavr.tech/empower/staking/empowervaloper1l4xt877lhhhm9573ewpxrcdl9x29n7scjrtdqw)[<img src='https://user-images.githubusercontent.com/44331529/205344966-57bf028d-da79-41d7-be38-7837553884ce.png' alt='discord' height='94'>](https://explorer.stavr.tech/neutron-testnet/staking/neutronvaloper1y535ugclzdhlyjd6wchl35eljvx5y9z24duqy3)[<img src='https://user-images.githubusercontent.com/44331529/205354941-c5f91544-c8e8-4399-b3c3-2d0d96607639.png' alt='discord' height='94'>](https://explorer.stavr.tech/dws/staking/dewebvaloper1jmxnrfmart0ksvj2exm3q0xnrczuqtvpmu4953)[<img src='https://user-images.githubusercontent.com/44331529/206961539-e1994db9-3fa8-4cf5-8ec6-7dc584d02bcd.png' alt='discord' height='94'>](https://explorer.stavr.tech/pylons/staking/pylovaloper16sttxsupvxyv8g2m8xejntxw4eukqqt77tflhh)[<img src='https://user-images.githubusercontent.com/44331529/207784609-27967990-0f51-4668-8352-4516ae80bb8c.png' alt='discord' height='94'>](https://telemetry.subspace.network/#list/0x43d10ffd50990380ffe6c9392145431d630ae67e89dbc9c014cac2a417759101)[<img src='https://user-images.githubusercontent.com/44331529/207784600-14a3ebf3-843f-4b64-960a-7a882ef36ef4.png' alt='discord' height='94'>](https://explorer.stavr.tech/okp4-testnet/staking/okp4valoper1sc4dkm38ejwftlxfwj9tx6dq8tdd3e9ygascc8)[<img src='https://user-images.githubusercontent.com/44331529/209769313-61838967-ba1b-4157-8c3d-e37a9c3e0f1d.png' alt='discord' height='94'>](https://explorer.postcapitalist.io/galaxy/staking/galaxyvaloper1tev3n7lu65v2ksg0ph0ywvz3kney50c0r9k6yp)[<img src='https://user-images.githubusercontent.com/44331529/210199415-0df88e5f-db74-44e8-b96f-214910a305c0.png' alt='discord' height='94'>](https://www.validators.app/validators?locale=en&network=mainnet&order=score&refresh=)[<img src='https://user-images.githubusercontent.com/44331529/216122991-5b6348d8-d648-4d02-ab71-8492374a6672.png' alt='discord' height='94'>](https://explorer.stavr.tech/mars/staking/marsvaloper1pc3ahwcurfedenmmndtk6w4nv7yj08ywfyenqf)[<img src='https://user-images.githubusercontent.com/44331529/219938844-7857f1f8-95dd-484a-b3e7-68bef97da8be.png' alt='discord' height='94'>](http://metrics.devnet.mundis.io:3000/d/local/devnet-cluster-monitor?orgId=1&refresh=30s&var-datasource=default&var-testnet=devnet&var-hostid=CS2EwUQ4gbqidxs1nXyxgf87a9LugwbU2mF7R4ohYrig)[<img src='https://user-images.githubusercontent.com/44331529/219938906-2e39cf81-8706-49e8-8f87-87686ebb5919.png' alt='discord' height='94'>](https://github.com/obajay)[<img src='https://user-images.githubusercontent.com/44331529/219938970-e579efde-27f7-4ad2-832c-8b7e13e51198.png' alt='discord' height='94'>](https://paloma.explorers.guru/validators)[<img src='https://user-images.githubusercontent.com/44331529/219939027-fe45ad23-5c9f-4633-b68a-b306e7da2503.png' alt='discord' height='94'>](https://testnet.whitelist.vip/)[<img src='https://user-images.githubusercontent.com/44331529/222785174-ba740678-61a1-4412-846e-ff114c081b05.png' alt='discord' height='94'>](https://explorer.sxlzptprjkt.xyz/goa-corrino/staking/corrinovaloper1a047r604jzwdv6wcv6m6drwf30v52vxmst0fw0)[<img src='https://user-images.githubusercontent.com/44331529/224542786-25510add-e2a7-4e2c-b1e6-2df6e6d02826.png' alt='discord' height='94'>](https://explorer.stavr.tech/celestia-testnet/staking/celestiavaloper1lv6254w0xz7t3qsgsueag7eexrdj9rpwg5uyer)[<img src='https://user-images.githubusercontent.com/44331529/224542948-87731d75-9df0-4a0f-a183-4a031b254ed5.png' alt='discord' height='94'>](https://explorer.stavr.tech/kyve-kaon/staking/kyvevaloper16qwtkeadppy3u9z6pu9tuy8zq02u3vecun3s0d)[<img src='https://user-images.githubusercontent.com/44331529/225524345-64fbb1d9-bddd-4c57-b829-a3425f4ee100.png' alt='discord' height='94'>](https://explorer.stavr.tech/nolus-testnet/staking/nolusvaloper1gqtd7nm09lyu8ql4m8r0ck4md7zdq2c76h5p49)[<img src='https://user-images.githubusercontent.com/44331529/225525385-fe8ce162-e049-4065-b3bd-c7eebfad0c0e.png' alt='discord' height='94'>](https://explorer.stavr.tech/ollo/staking/ollovaloper1hfsguqknteazy28ms9nm633yyf9tg4uz2gfr6a)[<img src='https://user-images.githubusercontent.com/44331529/225524982-40606468-c30a-451b-b738-8ed55121970d.png' alt='discord' height='94'>](https://explorer.stavr.tech/sge-testnet/staking/sgevaloper1g3a72tlm6v25y58pjy8x07far4hqj7cgxl3n9z)[<img src='https://user-images.githubusercontent.com/44331529/225702190-804d46ad-8397-4b9d-a63d-083c5b6c0ea4.png' alt='discord' height='94'>](https://explorer.stavr.tech/clannetwork/staking/clanvaloper1hzln3x9ve6s23ga7vtvrtfkxd2ac9duqf3e3ct)[<img src='https://user-images.githubusercontent.com/44331529/225705633-bd150638-71e2-4c35-9343-d401afc8ad3d.png' alt='discord' height='94'>](https://explorer.stavr.tech/sei/staking/seivaloper1u3rszcv0zjdj5cuw22cwe3955xk7zjjjex9t3u)[<img src='https://user-images.githubusercontent.com/44331529/226529829-4823b665-1a77-4292-b303-6ee777b357ac.png' alt='discord' height='94'>](https://explorer.stavr.tech/coreum-testnet/staking/testcorevaloper1p0gg6tuzgmw7lylwlg5l9hda3pj5whhcryxwwq)[<img src='https://user-images.githubusercontent.com/44331529/227698647-122b4699-e575-4f36-be19-e588613e37e9.png' alt='discord' height='94'>](https://explorer.stavr.tech/quasar-testnet/staking/quasarvaloper1qucu6jc20jcf5tj6r7n8ppd4sl9n67cmcqsqyp)[<img src='https://user-images.githubusercontent.com/44331529/228274088-aeda7f4e-ce86-4399-92e8-7ab4c0241b34.png' alt='discord' height='94'>](https://explorer.stavr.tech/nois/staking/noisvaloper1enwhnv85g4n99a2kzg8gey22xu6u43l4cxj824)[<img src='https://user-images.githubusercontent.com/44331529/229682480-cd150c12-765c-444f-889e-8ee88ea53e1f.png' alt='discord' height='94'>](https://explorer.stavr.tech/aura-testnet/staking/auravaloper1ucp33srru7g45ku6w207kc4hy6xd6psvmxw3xf)
 



 
 </details>
 <br />
<br />
  </div>
</div>


We help projects develop at an early stage, we develop and help the community, and we also support them after the release.

Our services include:
🔥 API / REST Endpoint
🔥 RPC Endpoint
🔥 gRPC Endpoint
🔥 Web gRPC Endpoint
🔥 SnapShots
🔥 State Sync
🔥 Archive node
🔥 Genesis file
🔥 IBC Relayers
🔥 Seed Node
🔥 Live Peers
🔥 Genesis
🔥 Addrbook file
and other.

[GitHub](https://github.com/obajay)
[Explorer](https://explorer.stavr.tech)
[Helpful Guides](https://github.com/obajay/nodes-Guides)
[Services](https://github.com/obajay/StateSync-snapshots)
[Monitoring](https://tenderdutyv2.stavr.tech)