### PR TITLE
Add MohismStake as Pre-Genesis Validator

### DIFF
--- a/namada-public-testnet-9/MohismStake.toml
+++ b/namada-public-testnet-9/MohismStake.toml
@@ -1,0 +1,9 @@
+[validator.MohismStake]
+consensus_public_key = "00580d453d8b8b9e6cc41d5e86c2ac2ed14c643a640755682ba010158a696ad2a6"
+account_public_key = "00add83fa538a77a6c762fb991a8b765626752b50ff084b199a41e04ffcd81ac67"
+protocol_public_key = "00786c4cd74ab68da1590921a7897f96bd6a00e693c414a30b735b122192a5ac2f"
+dkg_public_key = "6000000052c116dd30dbf8f0d4e0c187f6108c4b70c114f69fcff56e442b3d26052f7959f16c7f6faefc4c729d3090f4a42ab50499d922a705fc99460635be07315d5f155ec77e8054d4ef924b24823cdf1bc2ba48de90f0c30ceb9e32a83596479d3f90"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "159.69.76.171:26656"
+tendermint_node_key = "002c288a5d353c47d0b031d5f3c9b108d1d3ca669b4f6f625fab0afae0a6784c39"


### PR DESCRIPTION
Dear Namada Team,

I'm a cryptocurrencies enthusiast and a web3 developer, meanwhile I'm community member of several blockchain projects. Now I'm maintaining several staking pools for various protocols, on both mainnet and testnet, providing some feedbacks of the running of node software, include feature improvements and bug confirmation, helping community to improve the security of protocol's ecosystem.

I'm familiar with Bitcoin consensus protocol, Ouroboros consensus protocol, zk-snark, and rollups of some L2 protocol, skilled in program language such as Java, JavaScript, C, Dart, Solidity and some other script languages, skilled in Linux, Docker, writing some services scripts. During my life of cryptocurrency, I developed some script bots to help pool operator to operate their pools easily, also some of my community tools are granted by protocol's foundation.

I appreciate your consideration and look forward to the opportunity to contribute to Namada community.

I have successful node operating experience on several protocols, list part's of them below:

1. Mina: I'm the GFM(Genesis Founding Member) member of Mina protocol, walkthrough the whole course of Mina protocol. During the lifecycle of Mina's GFM, I helped to translate the documents of zk-snarks, and contribute to Mina's wiki. Improve the service of Mina procedure on Linux, finding and confirming bugs and help to re-produce them, catch logs, then trace them on github. Set up server for running Prometheus and Grafana to monitor my pool's health.

Help community member on their developing works, such as key managing, secret key sampling, and RPC api usage.

In March 2021, I helped to launch the network of Mina, now I'm maintaining a private pool node of Mina on mainnet and meanwhile a pool node on devnet, which is for zksnark-apps.

2. Near: I joined in the StarWar program of near protocol during its incentive testnet. My contribution includes run the node on testnet and betanet, compile the new binary from source code, helping community to find the right way to stabilise the node running, keep the online rate larger than 99%, report and confirm bugs; developed a bot to monitor the seat price of future epoch(mainly for epoch T+1 and T+2), and open sourced it to the community, it can help users to identify if their delegation can increase the seat for future epochs. Set up server for running Prometheus and Grafana, which is used to monitor the node's health. 

After testnet, I joined the OSA guild community of near, operating test nodes there and developed a faucet to help future member to get token easily to start their nodes.

Now I'm maintaining a mainnet validator node, which is delegated from Near foundation.

3. Cardano: I've joined Cardano's incentive testnet, operating staking pool node and relay node on testnet, helping small pool nodes with each other to get the chance of producing blocks, monitoring the combat of block producing on slot, improve the script of setting up staking pool node.

4. Aleo: Operating validator node on Aleo incentive testnet, help community members to optimize their server and get more chances to produce blocks. Helping core team to prevent the overwhelming anonymous control the network(Because of the Aleo's POW like protocol).

5. ChainFlip: I've joined ChainFlip SoundCheck incentive testnet, operating validator nodes on testnet, change the status of validator to help finding potential issues of project. Help community members to setting up their nodes, suggest UI improvements to delegation board, use Prometheus and Grafana to monitor the health of node.


Contact Information
Discord: viboracecata#5541
Telegram: @leesimin01
Email: viboracecata@gmail.com
Medium: https://medium.com/@viboracecata

Sincerely,