### PR TITLE
Update NODERSTEAM.toml for v0.20

### DIFF
--- a/namada-public-testnet-11/NODERSTEAM.toml
+++ b/namada-public-testnet-11/NODERSTEAM.toml
@@ -1,0 +1,11 @@
+[validator.NODERSTEAM]
+consensus_public_key = "009ede266d9095f4ddc99bd0583d236fbf444203af4cd74de6fad7d4b10ada34f5"
+eth_cold_key = "010362728594b38a504f956c12ebc73680d3387cd39e183178ba173057c4442eb1b1"
+eth_hot_key = "010229844df6be22b906c5ab8d7e4a60cf84f2a80562befead2fa91b3347cc26555e"
+account_public_key = "00e6ec7704ae888bf3379628e3f3fe0b86c21b1bf6b4d4ba26b24cd7f20634fd39"
+protocol_public_key = "004c0eb0bf173a920924ccfd71867a4d0c03151d32e25f2bb63dc25bfe7806647b"
+dkg_public_key = "60000000e51dbf6ce336509f63ed028ad932e31086e696e14f0dedca256c429aaeb417e8e6ab0d87fbfcfdfcbec270b2791e5518abc7a684a1bfcc128121cdae4f33dd3573391f7f4641169ee7fb2c0bcca1d70d2eb585921fe964e6d75c8191be9ba189"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "139.180.217.51:26656"
+tendermint_node_key = "00213c31186c0c890c2f65a91cff0a0ad835e533878e6e65f15cfc92b006a02c9a"


### PR DESCRIPTION
We are pregensis validators from 5 networks and we launched on time in each network, I didn’t quite understand why you closed the last PR

The link to the 5 testnet commit is here and it was merged, I can also provide pregenisys files from the 5 network

https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-5/NODERSTEAM.toml