### PR TITLE
Update blockonaut.toml for v0.20 - IP change

### DIFF
--- a/namada-public-testnet-11/blockonaut.toml
+++ b/namada-public-testnet-11/blockonaut.toml
@@ -1,0 +1,11 @@
+[validator.blockonaut]
+consensus_public_key = "00b6a517afe9a4efdf0f6741ad63dee279563f614d9d985f9a4fcbde89cd084dc6"
+eth_cold_key = "0103c628abc18d6fe67108dcb3c455eb2603c3cecfa67cbdba34d447afe4b037a469"
+eth_hot_key = "01033763acbfa5023039b01fd1361d3f57ba4e467d69e34258e737c42dce447a387b"
+account_public_key = "00bff8b27dcfe07baab30ed05bf009f61cb86d4bd93a9a4d0d674ddeb6962033a0"
+protocol_public_key = "000a0058de7985a61228ebc043ca5d7982a6b11202091894d4ab2cadd40450fff1"
+dkg_public_key = "60000000f2d386cc337c5535e08235586db365353faff8009597dd2a86e21f823473573868a844b93eb0030f832177282fa1f311332457e0f672f27f16f06534d572bf490d621b7c63074f5ff458f22471f82c7f8b1fd1b16e5f412a17efb51f1fe2de89"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "65.109.52.162:26656"
+tendermint_node_key = "0064e3cc7e8dba33124d67732c8eecab5a69f8b06132790a10be0e6ad470a9b1dd"


### PR DESCRIPTION
Update blockonaut.toml
IP changed after server migration, so net_address is changed.

Actice since public-testnet-2:

https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-2/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-3/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-4/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-5/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-6/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-7/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-8/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-9/blockonaut.toml https://github.com/anoma/namada-testnets/blob/main/namada-public-testnet-10/blockonaut.toml