### PR TITLE
Update CB-Validator.toml for v0.20

### DIFF
--- a/namada-public-testnet-11/CB-Validator.toml
+++ b/namada-public-testnet-11/CB-Validator.toml
@@ -1,0 +1,11 @@
+[validator.CB-Validator]
+consensus_public_key = "0042e43a11eda273f4c699f5ebc14d44f66998378ab2be313ae5f1234b017b4df2"
+eth_cold_key = "01038a9f98f16a412bd73f6a5a65b6baaef637c3eab0f8a814ebc30317fb25ba2b68"
+eth_hot_key = "0103754b75e6c5493619e2656b0aad0305bab2fdfa814005604dcde2caad30b39049"
+account_public_key = "00b464d9947e03aec6a65584b8d6a8ec83a8803bb977e11c3c237c33a2a4cf54ed"
+protocol_public_key = "0098b4741a715fc35ee1c17bec6070ec81daaa5651a638f46ec80155bea215edf5"
+dkg_public_key = "6000000093cced7ca7696a3d3a6565f6bd5466e1d7f14d683ce2a5d290a5e74f39c6603a2d9120797d26c6d116c640f0b9b4f2179c56d0b7d0f56541eda4836e80a2bf07dd79e87b8df317ab8ff348d7b65f2f6ffa3dd82d5fc1ab452ec54f979eb1f887"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "65.21.229.248:26656"
+tendermint_node_key = "0018ffdbd15101e834e55304f61ff5d808df1b74ca9872e0e7e996aa5a3a46cfa3"


### PR DESCRIPTION
Pre-genesis since **Public Testnet 2**. Ref: https://github.com/anoma/namada-testnets/pull/371

## Description

## If this is an UPDATE for a previous genesis validator
Checks are made against your `net_address`. If this has changed since the previous testnet, make sure you provide links of previous prs merged from your previous git username.

Thanks in advance!

## Checklist before merging to `draft`
- [ ] Only one toml is added in this PR
- [ ] The file being added is indeed a .toml file
- [ ] The toml being added is to the correct folder, and only to the correct folder
- [ ] The `eth_hot_key` and `eth_cold_key` are present