### PR TITLE
Add VanGogh validator

### DIFF
--- a/namada-public-testnet-11/VanGogh.toml
+++ b/namada-public-testnet-11/VanGogh.toml
@@ -1,0 +1,11 @@
+[validator.VanGogh]
+consensus_public_key = "00682692afb12e508952175d177bf9543f63af6caf9de99491af695ce57b7e981c"
+eth_cold_key = "01021e64fff8c6e6d59425f293259677c5fbeb7d1e1810d8d7c929c4f9941523e9e6"
+eth_hot_key = "01025d385397ec6fa190205bc33ff419f0b6b8e6d811de652da54246d028f45cfdd1"
+account_public_key = "00fef9e990912fb89fecd1040af6d02ba0938d99f0e8832b013f9352f24e339238"
+protocol_public_key = "00c89e3b2f8bb86291b6521f336944e7d0baa0b2a292aed8f82d66787968bf9a76"
+dkg_public_key = "600000005cd1bbf84ab1d052b02728de4fc7ae7643df5ec9bb47fab12cc5b956bfe499a88edc662434aaf5f9cb6d900bfe99dd13c4bdf8fe22e7072c586faca6fbd8e07ce9a586d7e69c3271ea5a7622a81ddc9ec5935cae0cb0e79a6588485c9c97d718"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "95.217.72.99:26656"
+tendermint_node_key = "0098bec39c44a759a1d7d8220e41ffb961d1b8af7aa57bcee22ddcbeec21e2b085"


### PR DESCRIPTION
Participated in testing: Aptos, NYM, Kujira, Massa, Nolus, Obol, Sui, Minima, Nibiru, Paloma, StarkNet etc

## Description

## If this is an UPDATE for a previous genesis validator
Checks are made against your `net_address`. If this has changed since the previous testnet, make sure you provide links of previous prs merged from your previous git username.

Thanks in advance!

## Checklist before merging to `draft`
- [x] Only one toml is added in this PR
- [x] The file being added is indeed a .toml file
- [x] The toml being added is to the correct folder, and only to the correct folder
- [x] The `eth_hot_key` and `eth_cold_key` are present