### PR TITLE
Update CryptoSJnet.toml migrated namada to the fixed production network  ( IP and port )

### DIFF
--- a/namada-public-testnet-13/CryptoSJnet.toml
+++ b/namada-public-testnet-13/CryptoSJnet.toml
@@ -7,5 +7,5 @@ protocol_public_key = "00921d30a8225fc1e24e10c4237e05e0ca5a0ae1f22bd4d2a831dc1fd
 dkg_public_key = "60000000eb330cbbb5c5c4e359dace9674998de2487b422cc02ab94f63a48757bd4865e1b385f82459a0c577519df9cc40708d125f5b22b4d82338f1d0ea87555ea641e3b06b18134c2e529e313cfa98ba2bc7b8451750c82f6edd8f6820d2de2d94c988"
 commission_rate = "0.05"
 max_commission_rate_change = "0.01"
-net_address = "86.98.163.119:26676"
+net_address = "65.108.31.106:10904"
 tendermint_node_key = "00fd6e2df654ea604fda8a555131bb26a73722e85cb85c3c028f876ac96fd074c2"


### PR DESCRIPTION

as we get closer and closer to mainnet i will move namada to the production network for premenet IP and Port also to test the HA .

previous PR 
https://github.com/anoma/namada-testnets/pull/1158

https://github.com/msobh13/namada-testnets/blob/patch-5/namada-public-testnet-9/CryptoSJ.net.toml

https://github.com/msobh13/namada-testnets/blob/patch-5/namada-public-testnet-8/CryptoSJ.net.toml

https://github.com/msobh13/namada-testnets/blob/patch-5/namada-public-testnet-7/CryptoSJ.net.toml

https://github.com/msobh13/namada-testnets/blob/patch-5/namada-public-testnet-6/CryptoSJ.net.toml

https://github.com/msobh13/namada-testnets/blob/patch-5/namada-public-testnet-10/CryptoSJ.net.toml




## Description

## If this is an UPDATE for a previous genesis validator
Checks are made against your `net_address`. If this has changed since the previous testnet, make sure you provide links of previous prs merged from your previous git username.

Thanks in advance!

## Checklist before merging to `draft`
- [ ] Only one toml is added in this PR
- [ ] The file being added is indeed a .toml file
- [ ] The toml being added is to the correct folder, and only to the correct folder
- [ ] The `eth_hot_key` and `eth_cold_key` are present