### PR TITLE
Update Wetez.toml for testnet-15

### DIFF
--- a/namada-public-testnet-15/Wetez.toml
+++ b/namada-public-testnet-15/Wetez.toml
@@ -1,0 +1,49 @@
+[[established_account]]
+vp = "vp_user"
+threshold = 1
+public_keys = ["tpknam1qp5a2cmmjeuqs2eu6kcnf977zt6dp8gvsp0qle7xs8emv573g9j75230vu2"]
+
+[[validator_account]]
+address = "tnam1qx026fggrkaz0tzftlj43a4j8tms4w7uxugsy4kh"
+vp = "vp_user"
+commission_rate = "0.05"
+max_commission_rate_change = "0.01"
+net_address = "178.63.105.179:26656"
+
+[validator_account.consensus_key]
+pk = "tpknam1qrsqjl4z937wly4dg0fdnwd30z5s60msugx00aafy7magdn0qvtlsfd43l2"
+authorization = "signam1qrup6aywymt3yk2uuxrrw5sgl7vj58np6ez5u5rwu9tda6lq98vegn0xdywa278asq2zaz789e4w9t2l3dqslxrax2hqhw96f6ac2tc2ayz0xa"
+
+[validator_account.protocol_key]
+pk = "tpknam1qp28g0gkhsg2hwgmrycwznpy9t3axuterwt4ydn93wuzzgccmt59kpyjtew"
+authorization = "signam1qprgkh4c2256vn54d4c3xfdaf8xe0dkat7qyq48zu3pdyfx6ye03zzhwghz3pez55vs238rg6fagswqjtgwunc5dletq0pgxsgyj2es26j0dqv"
+
+[validator_account.tendermint_node_key]
+pk = "tpknam1qrxazrl8ueune006c96jefclzt078p8k4sfgytvcjn3qet0t0uuwjr56sm3"
+authorization = "signam1qzreg0lwl360tq4fz9q237tlhnvjagnx6ckma2fxnvcgfm2awpjshx5nnlf4q2cpynezqajxsvtayp63c3zzxnhgskls76e2fwprnhsvdgshlq"
+
+[validator_account.eth_hot_key]
+pk = "tpknam1qypdmcdrf7thzmh3gd894x9h8pcy0r57srhevddzn8lahvx49569n4qa9pvs5"
+authorization = "signam1q9wc6apm7k3lu0hkhpkvqp4ckp0wxwdzlgt5seezwjp8tws4x3j3c9y99knk24yvexly7fjdphpzy7kc7vneml4j5wnrj8cck3vvye0rqqz4wdzg"
+
+[validator_account.eth_cold_key]
+pk = "tpknam1qypcrskdmavl8psgtz47ml763mvcs6cpemx7l2na8uctf03p87p26sgrfm5s2"
+authorization = "signam1q8jtt3fxrtd3hk97r7w3lf5y7jh7dm8wxa47hulf3l0qf6x8f3cx6tq4uh4xaw77vmg8dfrycd8094l2579rklxnfdfdjm9pflz8qg0qqy3a5r4e"
+
+[validator_account.metadata]
+email = "merlin@wetez.io"
+discord = "merlinwetez"
+elements = "@merlinwetez:matrix.org"
+telegram = "@cyber_doge"
+twitter = "@wetez_stake"
+
+[validator_account.signatures]
+tpknam1qp5a2cmmjeuqs2eu6kcnf977zt6dp8gvsp0qle7xs8emv573g9j75230vu2 = "signam1qzmq06nu6uag2l78dv87m2vqkl5f70dxkt9g9g2le2ucg4glng6frhrm93zljn7a9py4anm79alldkg5u5hz40v8fnff9h30chvtczcxe36zc8"
+
+[[bond]]
+source = "tnam1qx026fggrkaz0tzftlj43a4j8tms4w7uxugsy4kh"
+validator = "tnam1qx026fggrkaz0tzftlj43a4j8tms4w7uxugsy4kh"
+amount = "1000000"
+
+[bond.signatures]
+tpknam1qp5a2cmmjeuqs2eu6kcnf977zt6dp8gvsp0qle7xs8emv573g9j75230vu2 = "signam1qq0lgc7ewcyzpdarq9ctp0mnjym2ch5dmgh6s2dpjavuk94u0csrwhe2na2a8aln0mhk8ea60c0lvdk6sn0atgfn3h5ulk26aqjx90cfgn5qr9"

--- a/namada-public-testnet-15_legacy/Wetez.toml
+++ b/namada-public-testnet-15_legacy/Wetez.toml
@@ -1,49 +1,16 @@
-[[established_account]]
-vp = "vp_user"
-threshold = 1
-public_keys = ["tpknam1qp5a2cmmjeuqs2eu6kcnf977zt6dp8gvsp0qle7xs8emv573g9j75230vu2"]
-
-[[validator_account]]
-address = "tnam1qx026fggrkaz0tzftlj43a4j8tms4w7uxugsy4kh"
-vp = "vp_user"
+[validator.Wetez]
+consensus_public_key = "0032f6c7e83eb8c5acffb3bad566cb51e855afb441ef4382e0ac13cfb1d12ab539"
+eth_cold_key = "01039c2f08cfa777762c8fb6202f6c74c2217a1914e132f7f4d68956f5ab1603a56a"
+eth_hot_key = "010250745c8a398b981b25e01a58644b763ae678513e2534f2c475f7f7c93588951a"
+account_public_key = "00d5c5c04bfd3adfe6aa3d63baaec078d21cc966e8797f129fadf609afe69faedc"
+protocol_public_key = "0013333a5708538dbfc99bb85cbb83047737e46884fb4b86d84f2354a786b2a4ca"
+dkg_public_key = "6000000048e177d32de8cfd8fd1fbd220f238639234f01ef8ac44e6fbfe7e8fae49ce54cee746193c3f076b65b13a4d44575130dd4d463abc7973bbd1b4df3ef54843176f877193c778862ee008c42183420566f1504d647dfdce6c7caf39e467262e80c"
 commission_rate = "0.05"
 max_commission_rate_change = "0.01"
 net_address = "178.63.105.179:26656"
-
-[validator_account.consensus_key]
-pk = "tpknam1qrsqjl4z937wly4dg0fdnwd30z5s60msugx00aafy7magdn0qvtlsfd43l2"
-authorization = "signam1qrup6aywymt3yk2uuxrrw5sgl7vj58np6ez5u5rwu9tda6lq98vegn0xdywa278asq2zaz789e4w9t2l3dqslxrax2hqhw96f6ac2tc2ayz0xa"
-
-[validator_account.protocol_key]
-pk = "tpknam1qp28g0gkhsg2hwgmrycwznpy9t3axuterwt4ydn93wuzzgccmt59kpyjtew"
-authorization = "signam1qprgkh4c2256vn54d4c3xfdaf8xe0dkat7qyq48zu3pdyfx6ye03zzhwghz3pez55vs238rg6fagswqjtgwunc5dletq0pgxsgyj2es26j0dqv"
-
-[validator_account.tendermint_node_key]
-pk = "tpknam1qrxazrl8ueune006c96jefclzt078p8k4sfgytvcjn3qet0t0uuwjr56sm3"
-authorization = "signam1qzreg0lwl360tq4fz9q237tlhnvjagnx6ckma2fxnvcgfm2awpjshx5nnlf4q2cpynezqajxsvtayp63c3zzxnhgskls76e2fwprnhsvdgshlq"
-
-[validator_account.eth_hot_key]
-pk = "tpknam1qypdmcdrf7thzmh3gd894x9h8pcy0r57srhevddzn8lahvx49569n4qa9pvs5"
-authorization = "signam1q9wc6apm7k3lu0hkhpkvqp4ckp0wxwdzlgt5seezwjp8tws4x3j3c9y99knk24yvexly7fjdphpzy7kc7vneml4j5wnrj8cck3vvye0rqqz4wdzg"
-
-[validator_account.eth_cold_key]
-pk = "tpknam1qypcrskdmavl8psgtz47ml763mvcs6cpemx7l2na8uctf03p87p26sgrfm5s2"
-authorization = "signam1q8jtt3fxrtd3hk97r7w3lf5y7jh7dm8wxa47hulf3l0qf6x8f3cx6tq4uh4xaw77vmg8dfrycd8094l2579rklxnfdfdjm9pflz8qg0qqy3a5r4e"
-
-[validator_account.metadata]
+tendermint_node_key = "00d560cea863baeddb704b7db2acace32ad353ed4a907f6dbce8b30d6efe3c8a01"
 email = "merlin@wetez.io"
 discord = "merlinwetez"
 elements = "@merlinwetez:matrix.org"
 telegram = "@cyber_doge"
 twitter = "@wetez_stake"
-
-[validator_account.signatures]
-tpknam1qp5a2cmmjeuqs2eu6kcnf977zt6dp8gvsp0qle7xs8emv573g9j75230vu2 = "signam1qzmq06nu6uag2l78dv87m2vqkl5f70dxkt9g9g2le2ucg4glng6frhrm93zljn7a9py4anm79alldkg5u5hz40v8fnff9h30chvtczcxe36zc8"
-
-[[bond]]
-source = "tnam1qx026fggrkaz0tzftlj43a4j8tms4w7uxugsy4kh"
-validator = "tnam1qx026fggrkaz0tzftlj43a4j8tms4w7uxugsy4kh"
-amount = "1000000"
-
-[bond.signatures]
-tpknam1qp5a2cmmjeuqs2eu6kcnf977zt6dp8gvsp0qle7xs8emv573g9j75230vu2 = "signam1qq0lgc7ewcyzpdarq9ctp0mnjym2ch5dmgh6s2dpjavuk94u0csrwhe2na2a8aln0mhk8ea60c0lvdk6sn0atgfn3h5ulk26aqjx90cfgn5qr9"


### PR DESCRIPTION
# Description

All previous genesis validators should name their PRs "Update {validator_alias}.toml for tesntet-15" and provide links to previous PRs merged.

Previous prs merged:

[Update Wetez.toml for testnet 15](https://github.com/anoma/namada-testnets/pull/1892)
[Update Wetez.toml for v0.20](https://github.com/anoma/namada-testnets/pull/1227)
[Wetez ’s Application for Pre-Genesis Validator](https://github.com/anoma/namada-testnets/pull/716)

## If this is an UPDATE for a previous genesis validator

Checks are made against your `net_address`. If this has changed since the previous testnet, make sure you provide links of previous prs merged from your previous git username.

Thanks in advance!

## Checklist before merging

- [x] Only one toml is added in this PR
- [x] The file being added is indeed a .toml file
- [x] The toml being added is to the correct folder, and only to the correct folder
- [x] The `eth_hot_key` and `eth_cold_key` are present
- [x] The `email`, `discord`, `elements` `telegram`, and `twitter` fields are present and valid
